### PR TITLE
Fix typo in README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The package can be installed directly to any compatible Python environment (>3.1
 
 ```pip install microlensing_photometry```
 
-To install the scripts used to run the pipeline, it is best to clone this respository.
+To install the scripts used to run the pipeline, it is best to clone this repository.
 
 ## Documentation
 The documentation for this package can be found on [ReadTheDocs](https://lcogt-microlensing-photometry.readthedocs.io/en/latest/).


### PR DESCRIPTION
## Summary
- Fixes "respository" → "repository" in the installation section of README.md

## Test plan
- N/A — documentation-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)