### PR TITLE
Fix slow lightcurve_by_position.py

### DIFF
--- a/image_reduction/IO/lightcurve_by_position.py
+++ b/image_reduction/IO/lightcurve_by_position.py
@@ -85,7 +85,6 @@ def aperture_timeseries_on_pixel(params, log=None):
     obs_set = lcoobs.get_observation_metadata.fn(params['red_dir'], log=log)
 
     dataset = lcoapphot.AperturePhotometryDataset()
-    dataset.load_phot_store(params['red_dir'], len(star_catalog.sources), obs_set)
     dataset.load_norm_flux(params['red_dir'])
 
     # Target coordinates need to be in pixel coordinates

--- a/image_reduction/infrastructure/data_classes.py
+++ b/image_reduction/infrastructure/data_classes.py
@@ -1,5 +1,5 @@
 import os
-from astropy.table import Table, Column
+from astropy.table import Table, Column, vstack
 from astropy import units as u
 from astropy.io import ascii
 from astropy.io import fits
@@ -112,6 +112,38 @@ class ObservationSet(object):
         :return: Information added to self.table
         """
 
+        row = self.build_observation_row(file_path, header=header)
+        self.table.add_row(row)
+
+    def add_observations(self, rows):
+        """
+        Method to add multiple observation rows to the table in a single operation.
+
+        Calling Table.add_row() repeatedly is O(N) per call (it rebuilds the table each
+        time), so for large numbers of new rows this is O(N^2) overall. Building the new
+        rows as a separate Table and vstacking once avoids that.
+
+        :param rows: list of row lists, as returned by build_observation_row()
+        """
+
+        if len(rows) == 0:
+            return
+
+        new_table = Table(rows=rows, names=self.table.colnames)
+        if len(self.table) == 0:
+            self.table = new_table
+        else:
+            self.table = vstack([self.table, new_table])
+
+    def build_observation_row(self, file_path, header=None):
+        """
+        Method to extract a row of observation metadata from the FITS header of a single file,
+        without mutating self.table.
+
+        :param header: Astropy FITS header object
+        :return: list  Row of table data
+        """
+
         # Read header info if not parsed to method
         if not header:
             header = fits.getheader(file_path)
@@ -184,7 +216,7 @@ class ObservationSet(object):
             processed
         ]
 
-        self.table.add_row(row)
+        return row
 
     def check_file_in_set(self, filename):
         """

--- a/image_reduction/infrastructure/observations.py
+++ b/image_reduction/infrastructure/observations.py
@@ -30,6 +30,10 @@ def get_observation_metadata(red_dir, log=None):
 
     # Review all observations in the list and extract header data where necessary
     lcologs.log('Reviewing all images to extract header information', 'info', log=log)
+    # Membership testing against an Astropy Column is O(N); building a set once up front
+    # avoids repeating that scan for every file in obs_list (which was O(N^2) overall).
+    existing_files = set(obs_set.table['file'])
+    new_rows = []
     for i, file_name in enumerate(obs_list):
         if i%10 == 0:
             lcologs.log(
@@ -37,7 +41,7 @@ def get_observation_metadata(red_dir, log=None):
                 'info',
                 log=log
             )
-        if file_name not in obs_set.table['file']:
+        if file_name not in existing_files:
             file_path = os.path.join(red_dir, file_name)
 
             # A deepcopy of the header object is taken so that the file itself can be properly
@@ -53,11 +57,15 @@ def get_observation_metadata(red_dir, log=None):
                     if hdu.header['EXTNAME'] == 'LCO MICROLENSING PHOTOMETRY UPDATED WCS':
                         hdr0 = update_wcs_parameters(hdu.header, hdr0)
 
-                obs_set.add_observation(file_path, hdr0)
+                new_rows.append(obs_set.build_observation_row(file_path, hdr0))
 
             # Ensure FITS files close properly
             hdul.close()
             del hdul
+
+    # Add all newly-found observations to the table in a single bulk operation, rather than
+    # one Table.add_row() call per file (which rebuilds the whole table each time).
+    obs_set.add_observations(new_rows)
 
     # Store summary of the dataset information
     obs_set.save(obs_set_file, log=log)


### PR DESCRIPTION
## Summary
- `dataset.load_phot_store()` in `lightcurve_by_position.py` was reading every per-image `raw_flux/*.parquet` file (1628+ files in the reported case) purely to populate fields (`raw_flux`, `sources`, `file`, `timestamps`) that are never used downstream — the lightcurve is built entirely from `dataset.flux`/`dataset.flux_err`, which come from the separate, cheap `load_norm_flux()` call. This dead read accounted for a ~17 minute stall observed in a production log.
- Fixed an unrelated O(N²) pattern in `get_observation_metadata()`: it tested file membership against an Astropy `Column` (O(N) per check) and called `Table.add_row()` once per new file (O(N) per call, rebuilding the table each time). Replaced with a `set` lookup and a single bulk insert (`ObservationSet.add_observations()`).

## Test plan
- [x] `pytest tests/` — same 4 pre-existing failures before and after this change (confirmed via `git stash`), no regressions, 17 passed / 1 skipped either way.
- [x] Re-run `lightcurve_by_position.py` against the reported dataset to confirm the runtime drops from ~17 minutes to seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)